### PR TITLE
Make curl follow redirects

### DIFF
--- a/languages/node/Dockerfile
+++ b/languages/node/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Joel Wurtz <jwurtz@jolicode.com>
 
 RUN apt-get install -y build-essential libssl-dev libmysqlclient-dev
 
-RUN curl https://raw.github.com/creationix/nvm/master/install.sh | sh
+RUN curl --location https://raw.github.com/creationix/nvm/master/install.sh | sh
 RUN echo "[[ -s $HOME/.nvm/nvm.sh ]] && . $HOME/.nvm/nvm.sh" >> /etc/profile.d/npm.sh
 RUN echo "[[ -s $HOME/.nvm/nvm.sh ]] && . $HOME/.nvm/nvm.sh" >> $HOME/.bashrc
 


### PR DESCRIPTION
curl requests to raw.github.com are no longer working without explicitely telling curl to follow redirect headers.
