### PR TITLE
Add support for pear/pecl

### DIFF
--- a/languages/php/5.3/Dockerfile
+++ b/languages/php/5.3/Dockerfile
@@ -1,5 +1,8 @@
 FROM jolicode/phpenv
 MAINTAINER Joel Wurtz <jwurtz@jolicode.com>
 
-RUN MAKEFLAGS=' -j8' LDFLAGS=-lstdc++ phpenv install 5.3.29 && phpenv global 5.3.29 && phpenv rehash
+RUN MAKEFLAGS=' -j8' LDFLAGS=-lstdc++ phpenv install 5.3.29 && \
+    phpenv global 5.3.29 && \
+    phpenv rehash && \
+    pear config-set php_ini $(php -r 'echo php_ini_loaded_file();')
 COPY jolicode.ini /home/.phpenv/versions/5.3.29/etc/conf.d/jolicode.ini

--- a/languages/php/5.4/Dockerfile
+++ b/languages/php/5.4/Dockerfile
@@ -1,5 +1,8 @@
 FROM jolicode/phpenv
 MAINTAINER Joel Wurtz <jwurtz@jolicode.com>
 
-RUN MAKEFLAGS=' -j8' phpenv install 5.4.34 && phpenv global 5.4.34 && phpenv rehash
+RUN MAKEFLAGS=' -j2' phpenv install 5.4.34 && \
+    phpenv global 5.4.34 && \
+    phpenv rehash && \
+    pear config-set php_ini $(php -r 'echo php_ini_loaded_file();')
 COPY jolicode.ini /home/.phpenv/versions/5.4.34/etc/conf.d/jolicode.ini

--- a/languages/php/5.5/Dockerfile
+++ b/languages/php/5.5/Dockerfile
@@ -1,5 +1,8 @@
 FROM jolicode/phpenv
 MAINTAINER Joel Wurtz <jwurtz@jolicode.com>
 
-RUN MAKEFLAGS=' -j8' phpenv install 5.5.18 && phpenv global 5.5.18 && phpenv rehash
+RUN MAKEFLAGS=' -j2' phpenv install 5.5.18 && \
+    phpenv global 5.5.18 && \
+    phpenv rehash && \
+    pear config-set php_ini $(php -r 'echo php_ini_loaded_file();')
 COPY jolicode.ini /home/.phpenv/versions/5.5.18/etc/conf.d/jolicode.ini

--- a/languages/php/5.6/Dockerfile
+++ b/languages/php/5.6/Dockerfile
@@ -1,5 +1,8 @@
 FROM jolicode/phpenv
 MAINTAINER Joel Wurtz <jwurtz@jolicode.com>
 
-RUN MAKEFLAGS=' -j8' phpenv install 5.6.2 && phpenv global 5.6.2 && phpenv rehash
+RUN MAKEFLAGS=' -j2' phpenv install 5.6.2 && \
+    phpenv global 5.6.2 && \
+    phpenv rehash && \
+    pear config-set php_ini $(php -r 'echo php_ini_loaded_file();')
 COPY jolicode.ini /home/.phpenv/versions/5.6.2/etc/conf.d/jolicode.ini

--- a/languages/php/default_configure_options
+++ b/languages/php/default_configure_options
@@ -1,6 +1,6 @@
 --enable-intl
 --with-openssl
---without-pear
+--with-pear
 --with-gd
 --with-jpeg-dir=/usr
 --with-png-dir=/usr


### PR DESCRIPTION
This makes it possible to install additional php packages/extensions before
running the tests through the pear/pecl commands.

Eg. add this to your .travis.yml file:

```
before_script:
- pecl install memcached
```
